### PR TITLE
Added RuhrSec 2025 (CFP in 2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Security conferences
 
+## In 2025
+
+| Name           | Location	| CfP ends |  Conference dates |
+| ---------------- | ------------- | ------------ | -------------------------|
+| [RuhrSec 2025](https://www.ruhrsec.de/2025/) | Bochum, Germany | November 10, 2024 | February 20-21, 2025 |
+
 ## In 2024
 
 | Name           | Location	| CfP ends |  Conference dates |


### PR DESCRIPTION
RuhrSec 2025 takes place in February 2025, but the CFP takes place this year.



> RuhrSec is the annual English speaking IT security conference with cutting-edge security talks by renowned experts. RuhrSec provides you with academic and industry talks, the typical University feeling, and a highly recommended social event.